### PR TITLE
Fix asset name spacing issue

### DIFF
--- a/nexus/nexus_test.go
+++ b/nexus/nexus_test.go
@@ -56,3 +56,23 @@ func TestNexusClientHTTPClient(t *testing.T) {
 		t.Error("Expected HTTPClient to be initialized")
 	}
 }
+
+func TestEncodeRepositoryPathWithSpaces(t *testing.T) {
+	encoded := encodeRepositoryPath("dir/with space/file name.txt")
+
+	expected := "dir/with%20space/file%20name.txt"
+	if encoded != expected {
+		t.Fatalf("Expected encoded path '%s', got '%s'", expected, encoded)
+	}
+}
+
+func TestRepositoryURLWithSpaces(t *testing.T) {
+	client := NewNexusClient("http://test-nexus.example.com", "testuser", "testpass", false, false)
+
+	got := client.repositoryURL("myrepo", "dir/with space/file name.txt")
+	expected := "http://test-nexus.example.com/repository/myrepo/dir/with%20space/file%20name.txt"
+
+	if got != expected {
+		t.Fatalf("Expected repository URL '%s', got '%s'", expected, got)
+	}
+}


### PR DESCRIPTION
URL-encode Nexus asset path segments to correctly handle spaces and special characters in asset names.

---
<a href="https://cursor.com/background-agent?bcId=bc-6543da9b-95a4-4e32-9bd9-b80ca4be8e2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6543da9b-95a4-4e32-9bd9-b80ca4be8e2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

